### PR TITLE
Check channel address when receiving payment in CLI

### DIFF
--- a/src/cli/handlers/payment.fif
+++ b/src/cli/handlers/payment.fif
@@ -138,6 +138,10 @@
   swap checkSigned
   // ( cliStateNice iou cliState iouPayload )
 
+  dup getIouPayloadAddr
+  5 pick getCliStateNiceCliState getCliStateAddr
+  addr= { fail"The payment is for a different channel" } ifnot
+
   _processPayment
   // ( cliStateNice cliState' )
 

--- a/src/lib/Address.fif
+++ b/src/lib/Address.fif
@@ -7,6 +7,17 @@ library Address  // Smart-contract address utilities
 "String.fif" include
 "ContractMessages.fif" include
 
+
+{ rot
+  =
+  ' = { 2drop false } cond
+} : addr=
+// ( wc1 addr1 wc2 addr2 -- bool )
+
+{ 8 i@+ 256 u@
+} : addr@
+// ( s -- wc addr )
+
 { 8 i@+ 256 u@+
 } : addr@+
 // ( s -- wc addr s )

--- a/src/lib/Iou.fif
+++ b/src/lib/Iou.fif
@@ -27,6 +27,11 @@ library Iou  // IOUs
 // ( iouPayload -- wc addr amount iou uome )
 
 { <s
+  addr@
+} : getIouPayloadAddr
+// ( iouPayload -- wc addr )
+
+{ <s
   addr@+ -rot drop drop
   120 u@
 } : getIouPayloadAmount


### PR DESCRIPTION
When an IOU is received its signature covers a channel address. There
are two possible ways to proceed:

1. Take this address and apply the IOU to the channel with this addres.
2. Ask the receiving user to provide the address of the channel that
   this IOU has been received from.

Had we gone with option 1, we would not have this issue.

But we chose option 2, ironically, as an extra precaution: by explicitly
giving the address of the channel “through” which the IOU was received,
the user explicitly confirms that they know what they are doing. In this
case we must check that the address that the user has given (and the we
use to locate the state of the channel) matches the one in the IOU.