### PR TITLE
Fix share check

### DIFF
--- a/src/cli/handlers/payment.fif
+++ b/src/cli/handlers/payment.fif
@@ -40,7 +40,7 @@
   5 pick swap addPaymentsStateWeOwe
   // ( globalState cliStateNice amount ourSk wc addr ourShare paymentsState' )
 
-  dup -rot getPaymentsStateBalance >=
+  dup -rot getPaymentsStateBalance negate >=
     { fail"Payment impossible: our commitment is not large enough" } ifnot
   // ( globalState cliStateNice amount ourSk wc addr paymentsState' )
   4 roll swap


### PR DESCRIPTION
We need to check that the new balance is acceptable, given the size of our committed share. The check is supposed to be “our share >= what we owe”.

Currently the check is “our share >= channel balance”, and this is wrong, because channel balance is how much we are _owed_. We have to negate it to get how much we _owe_.